### PR TITLE
Change user from jenkins to root and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ sudo yum install xroad-catalog-lister xroad-catalog-collector
 # or
 rpm -i install xroad-catalog-lister xroad-catalog-collector 
 ```
+Instructions on how to build the RPM packages using Docker can be found
+[here](xroad-catalog-collector/README.md#build-rpm-packages-on-non-redhat-platform)
+and
+[here](xroad-catalog-lister/README.md#build-rpm-packages-on-non-redhat-platform)
+
 Configure parameters in /etc/xroad/xroad-catalog/collector-production.properties, especially X-Road instance information and URL of security server.
 ```
 xroad-catalog.xroad-instance=FI

--- a/xroad-catalog-collector/README.md
+++ b/xroad-catalog-collector/README.md
@@ -3,12 +3,12 @@
 ## Build
 
 
-    $ gradle clean build
+    $ ../gradlew clean build
 
 
 ## Run
 
-    $ gradle bootRun
+    $ ../gradlew bootRun
 
 Or
 
@@ -32,6 +32,6 @@ Then run the collector with profile sshtest
 First make sure that xroad-catalog-persistence is located next to xroad-catalog-collector. The RPM build
  uses sql files from xroad-catalog-persistence/src/main/sql.
  
-    $ gradle clean build
+    $ ../gradlew clean build
     $ docker build -t collector-rpm packages/xroad-catalog-collector/docker
-    $ docker run -v $PWD/..:/workspace  -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro collector-rpm
+    $ docker run -v $PWD/..:/workspace collector-rpm

--- a/xroad-catalog-lister/README.md
+++ b/xroad-catalog-lister/README.md
@@ -4,12 +4,12 @@ WebService to produce list of xroad clients
 
 ## Build
 ```sh
-gradle clean build
+../gradlew clean build
 ```
 
 ## Run
 ```sh
-gradle bootRun
+../gradlew bootRun
 ```
 
 Or
@@ -24,6 +24,12 @@ Or
 | curl --header "content-type: text/xml" -d @src/main/doc/servicerequest.xml http://localhost:8080/ws |  All services in the system |
 | curl http://localhost:8080/ws/services.wsdl                                            |  Get WSDL                   |
 
+
+## Build RPM Packages on Non-RedHat Platform
+ 
+    $ ../gradlew clean build
+    $ docker build -t lister-rpm packages/xroad-catalog-lister/docker
+    $ docker run -v $PWD/..:/workspace lister-rpm
 
 
 

--- a/xroad-catalog-lister/packages/xroad-catalog-lister/docker/Dockerfile
+++ b/xroad-catalog-lister/packages/xroad-catalog-lister/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN yum -y install sudo git rpm-build java-1.8.0-openjdk-headless
 RUN yum clean all
 RUN sed -i 's/requiretty/!requiretty/' /etc/sudoers
 
-USER jenkins
+USER root
 CMD ["sh", "-c", "/workspace/xroad-catalog-lister/build_rpm.sh" ]

--- a/xroad-catalog-persistence/README.md
+++ b/xroad-catalog-persistence/README.md
@@ -22,17 +22,17 @@ and does not autocreate anything.
 
 ## Run
 ```sh
-gradle bootRun
+../gradlew bootRun
 ```
 or
 ```sh
-gradle bootRun -Dspring.profiles.active=production
+../gradlew bootRun -Dspring.profiles.active=production
 ```
 
 ## Test
 
 ```sh
-gradle test
+../gradlew test
 ```
 
 


### PR DESCRIPTION
- change xroad-catalog-lister Dockerfile to build packages as root, otherwise build would fail is user jenkins did not exist on host
- update documentation: use gradle wrapper everywhere, remove unnecessary volume mappings from docker commands, add more instructions about rpm builds

replaces PR https://github.com/vrk-kpa/xroad-catalog/pull/7